### PR TITLE
Rakefile: remove defunct rubyforge_project

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,6 @@ begin
   Jeweler::Tasks.new do |gem|
     gem.version = "#{config[:MAJOR]}.#{config[:MINOR]}.#{config[:PATCH]}"
     gem.name = "uri-redis"
-    gem.rubyforge_project = gem.name
     gem.summary = "URI-Redis: support for parsing redis://host:port/dbindex/keyname"
     gem.description = gem.summary
     gem.email = "delano@solutious.com"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436