### PR TITLE
Support URI v0.11.0

### DIFF
--- a/lib/uri/redis.rb
+++ b/lib/uri/redis.rb
@@ -90,7 +90,7 @@ module URI
     
   end
   
-  @@schemes['REDIS'] = Redis
+  register_scheme 'REDIS', Redis
 end
 
 


### PR DESCRIPTION
Fixed bellow error.
```
lib/uri/redis.rb:93:in `<module:URI>': uninitialized class variable @@schemes in URI (NameError)
```