### PR TITLE
Update URI-Redis gem to version 1.1.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,11 @@
 URI-Redis, CHANGES
 
+#### 1.1.0 (2024-04-04) ###############################
+
+* Fix for frozen strings issue.
+* Allow fow updated redis, tryouts releases. 
+
+
 #### 1.0.0 (2023-01-17) ###############################
 
 * CHANGE: Just a version bump to 1.0 for a full

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+ruby '>= 2.6.8'
+
 # Specify your gem's dependencies in uri-redis.gemspec
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,57 @@
+PATH
+  remote: .
+  specs:
+    uri-redis (1.0.0)
+      redis (~> 4.1, >= 4.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    drydock (0.6.9)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rainbow (3.1.1)
+    rake (13.2.0)
+    redis (4.8.1)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rubocop (1.62.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.2)
+      parser (>= 3.3.0.4)
+    ruby-progressbar (1.13.0)
+    storable (0.10.0)
+    sysinfo (0.10.0)
+      drydock (< 1.0)
+      storable (~> 0.10)
+    tryouts (2.2.0)
+      sysinfo (~> 0.10)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  arm64-darwin-22
+  ruby
+
+DEPENDENCIES
+  rake (~> 13.0)
+  rubocop (~> 1.21)
+  tryouts (~> 2.1, >= 2.1.1)
+  uri-redis!
+
+BUNDLED WITH
+   2.5.7

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ e.g.
     redis://host:port/dbindex
 
 ## Usage
-**
+
+```ruby
     require 'uri/redis'
 
     conf = URI.parse 'redis://localhost:4380/2'
@@ -16,7 +17,9 @@ e.g.
     conf.db                   # => 2
     conf.to_s                 # => redis://localhost:4380/2
     conf
-**
+```
+
+
 ## Installation
 
 Get it in one of the following ways:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# URI-Redis v1.0 (pre-release)
+# URI-Redis v1.1.0 (2024-04-04)
 
 Creates a URI object for Redis URLs.
 
@@ -28,11 +28,6 @@ Get it in one of the following ways:
 ## About
 
 * [Github](https://github.com/delano/uri-redis)
-
-
-## Credits
-
-* delano (https://delanotes.com/)
 
 
 ## License

--- a/lib/uri/redis.rb
+++ b/lib/uri/redis.rb
@@ -18,7 +18,6 @@ module URI
   #   uri = URI::Redis.build(host: "localhost", port: 6379, db: 2)
   #   uri.to_s #=> "redis://localhost:6379/2"
   class Redis < URI::Generic
-    VERSION = "0.4" unless defined?(URI::Redis::VERSION)
     DEFAULT_PORT = 6379
     DEFAULT_DB = 0
 

--- a/lib/uri/redis.rb
+++ b/lib/uri/redis.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+
 
 require "uri"
 require "redis"

--- a/lib/uri/redis/version.rb
+++ b/lib/uri/redis/version.rb
@@ -2,6 +2,6 @@
 
 module URI
   module Redis
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end

--- a/try/10_uri_redis_try.rb
+++ b/try/10_uri_redis_try.rb
@@ -1,5 +1,5 @@
 
-require "uri/redis"
+require_relative "../lib/uri/redis"
 
 ## Default database is 0
 uri = URI.parse "redis://localhost"

--- a/try/10_uri_redis_try.rb
+++ b/try/10_uri_redis_try.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 require "uri/redis"
 

--- a/uri-redis.gemspec
+++ b/uri-redis.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "URI-Redis: support for parsing Redis URIs like redis://host:port/dbindex"
   spec.homepage = "https://github.com/delano/uri-redis"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.5"
+  spec.required_ruby_version = ">= 2.6.8"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 

--- a/uri-redis.gemspec
+++ b/uri-redis.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "redis", "~> 4.1", ">= 4.1.0"
-  spec.add_development_dependency "tryouts", "~> 2.1", ">= 2.1.1"
+  spec.add_runtime_dependency "redis", ">= 4.8", "< 7"
+  spec.add_development_dependency "tryouts"
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
This pull request updates the URI-Redis gem to version 1.1.0. It includes the following changes:

- Added Gemfile lock

- Set minimum Ruby version to 2.6.8

- Fixed frozen string issue

- Allowed latest versions of dependencies

- Updated syntax highlighting

Please review and merge this pull request.