### PR TITLE
Update gem versions and remove Ruby version constraint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,22 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby:
-          - "3.1.2"
-          - "2.7.5"
+        include:
+          - ruby: '3.2.0'
+            bundler: latest
+            rubygems: latest
+
+          - ruby: '3.1.4'
+            bundler: latest
+            rubygems: latest
+
+          - ruby: '3.0'
+            bundler: latest
+            rubygems: latest
+
+          - ruby: '2.7'
+            bundler: '2.4.22'
+            rubygems: '3.2.3'
 
     steps:
     - uses: actions/checkout@v3
@@ -23,6 +36,13 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
+        rubygems: ${{ matrix.rubygems }}
+        bundler: ${{ matrix.bundler }}
+        # When the following is true, also run "bundle install",
+        # and cache the result automatically. Ran into an issue
+        # with the caching and multiple ruby version? See commit
+        # message for this change.
+        bundler-cache: false
+
     - name: Run the default task
       run: bundle exec rake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,5 +44,8 @@ jobs:
         # message for this change.
         bundler-cache: false
 
+    - name: Re-run bundle install
+      run: bundle install
+
     - name: Run the default task
       run: bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7.5
+  TargetRubyVersion: 2.7
 
 Gemspec/DeprecatedAttributeAssignment: # new in 1.30
   Enabled: true
@@ -171,6 +171,8 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   Enabled: false
   EnforcedStyle: double_quotes
+Style/FrozenStringLiteralComment:
+  Enabled: false
 
 Layout/LineLength:
   Max: 120

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,15 @@
 URI-Redis, CHANGES
 
+#### 1.1.1 (2024-04-05) ###############################
+
+* Remove minimum ruby version from Gemfile
+* Includes corrected Gemfile.lock file.
+
+
 #### 1.1.0 (2024-04-04) ###############################
 
 * Fix for frozen strings issue.
-* Allow fow updated redis, tryouts releases. 
+* Allow fow updated redis, tryouts releases.
 
 
 #### 1.0.0 (2023-01-17) ###############################

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-ruby '>= 2.6.8'
-
 # Specify your gem's dependencies in uri-redis.gemspec
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,10 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in uri-redis.gemspec
-gemspec
-
 gem "rake", "~> 13.0"
-
+gem "redis", ">= 4.8", "< 7"
 gem "rubocop", "~> 1.21"
+
+group :development do
+  gem "tryouts", "~>2.2.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,31 @@
 PATH
   remote: .
   specs:
-    uri-redis (1.0.0)
-      redis (~> 4.1, >= 4.1.0)
+    uri-redis (1.1.1)
+      redis (>= 4.8, < 7)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    connection_pool (2.4.1)
     drydock (0.6.9)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     parallel (1.24.0)
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
     rainbow (3.1.1)
-    rake (13.2.0)
-    redis (4.8.1)
+    rake (13.2.1)
+    redis (5.2.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.1)
+      connection_pool
     regexp_parser (2.9.0)
     rexml (3.2.6)
-    rubocop (1.62.1)
+    rubocop (1.63.4)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -32,8 +36,8 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     storable (0.10.0)
     sysinfo (0.10.0)
@@ -50,8 +54,8 @@ PLATFORMS
 DEPENDENCIES
   rake (~> 13.0)
   rubocop (~> 1.21)
-  tryouts (~> 2.1, >= 2.1.1)
+  tryouts
   uri-redis!
 
 BUNDLED WITH
-   2.5.7
+   2.5.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-PATH
-  remote: .
-  specs:
-    uri-redis (1.1.1)
-      redis (>= 4.8, < 7)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -53,9 +47,9 @@ PLATFORMS
 
 DEPENDENCIES
   rake (~> 13.0)
+  redis (>= 4.8, < 7)
   rubocop (~> 1.21)
-  tryouts
-  uri-redis!
+  tryouts (~> 2.2.0)
 
 BUNDLED WITH
    2.5.9

--- a/lib/uri/redis.rb
+++ b/lib/uri/redis.rb
@@ -1,5 +1,3 @@
-
-
 require "uri"
 require "redis"
 

--- a/lib/uri/redis/version.rb
+++ b/lib/uri/redis/version.rb
@@ -2,6 +2,6 @@
 
 module URI
   module Redis
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end

--- a/try/10_uri_redis_try.rb
+++ b/try/10_uri_redis_try.rb
@@ -1,5 +1,4 @@
-
-require_relative "../lib/uri/redis"
+require "uri/redis"
 
 ## Default database is 0
 uri = URI.parse "redis://localhost"

--- a/uri-redis.gemspec
+++ b/uri-redis.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name = "uri-redis"
   spec.version = URI::Redis::VERSION
   spec.authors = ["delano"]
-  spec.email = ["delano@solutious.com"]
+  spec.email = ["gems@solutious.com"]
 
   spec.summary = "URI-Redis: support for parsing Redis URIs"
   spec.description = "URI-Redis: support for parsing Redis URIs like redis://host:port/dbindex"
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_runtime_dependency "redis", ">= 4.8", "< 7"
-  spec.add_development_dependency "tryouts"
+  spec.add_development_dependency "tryouts", "2.2.0"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/uri-redis.gemspec
+++ b/uri-redis.gemspec
@@ -30,7 +30,5 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_runtime_dependency "redis", ">= 4.8", "< 7"
-  spec.add_development_dependency "tryouts", "2.2.0"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/uri-redis.gemspec
+++ b/uri-redis.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "URI-Redis: support for parsing Redis URIs like redis://host:port/dbindex"
   spec.homepage = "https://github.com/delano/uri-redis"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.8"
+  spec.required_ruby_version = ">= 2.7.5"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
This pull request updates several gems and their dependencies to their latest versions. It also removes the Ruby version constraint from the Gemfile. The changes include:

- Updating `redis` from 4.8.1 to 5.2.0 and adding `redis-client` dependency

- Bumping `rake` from 13.2.0 to 13.2.1

- Raising `rubocop` version from 1.62.1 to 1.63.4

- Increasing `parser` version from 3.3.0.5 to 3.3.1.0

- Updating `rubocop-ast` from 1.31.2 to 1.31.3

Additionally, the `uri-redis` version is corrected to 1.1.1 (was still 1.0.0) . The Ruby version constraint is removed from the Gemfile.
