### PR TITLE
Version bump: 1.1.2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,18 @@
 URI-Redis, CHANGES
 
+#### 1.1.2 (2024-05-02) ###############################
+
+* Same functionality as the now yanked 1.1.1 with
+  updated metadata, including:
+    * Remove minimum ruby version from Gemfile
+    * Corrected Gemfile.lock file with latest deps
+    * Improved Github Action workflow.
+    * Fixes for Rubocop complaints.
+
+
 #### 1.1.1 (2024-04-05) ###############################
 
-* Remove minimum ruby version from Gemfile
-* Includes corrected Gemfile.lock file.
-
+** Yanked May 2nd **
 
 #### 1.1.0 (2024-04-04) ###############################
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# URI-Redis v1.1.0 (2024-04-04)
+# URI-Redis v1.1.2 (2024-05-02)
 
 Creates a URI object for Redis URLs.
 

--- a/lib/uri/redis/version.rb
+++ b/lib/uri/redis/version.rb
@@ -2,6 +2,6 @@
 
 module URI
   module Redis
-    VERSION = "1.1.1"
+    VERSION = "1.1.2"
   end
 end


### PR DESCRIPTION
This pull request includes a version bump to 1.1.2. The update includes updated metadata, such as removing the minimum ruby version from the Gemfile, correcting the Gemfile.lock file with the latest dependencies, improving the Github Action workflow, and fixing Rubocop complaints. The previous version 1.1.1 has been yanked.