### PR TITLE
Support rediss:// protocol 

### DIFF
--- a/lib/uri/redis/version.rb
+++ b/lib/uri/redis/version.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
+require "uri/generic"
 
 module URI
-  module Redis
+  class Redis < URI::Generic
     VERSION = "1.2.0"
     SUMMARY = "A Ruby library for parsing, building and normalizing redis URLs"
   end

--- a/lib/uri/redis/version.rb
+++ b/lib/uri/redis/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "uri/generic"
 
 module URI

--- a/try/10_uri_redis_try.rb
+++ b/try/10_uri_redis_try.rb
@@ -26,3 +26,8 @@ uri = URI.parse "redis://localhost/2/v1:arbitrary:key"
 uri.key = "v2:arbitrary:key"
 uri.to_s
 #=> 'redis://localhost/2/v2:arbitrary:key'
+
+## Support rediss
+uri = URI.parse "rediss://localhost"
+[uri.scheme, uri.conf]
+#=> ["rediss", {:host=>"localhost", :port=>6379, :db=>0, :ssl=>true}]


### PR DESCRIPTION
Moving from a Module to a Class for the version is the way to fix the error of double declaration : 

```
irb(main):003> require_relative 'lib/uri/redis/version'
=> true
irb(main):005> require_relative 'lib/uri/redis'
/src/lib/uri/redis.rb:19:in `<module:URI>': Redis is not a class (TypeError)
/src/lib/uri/redis/version.rb:5: previous definition of Redis was here
[...]
```

```
irb(main):001> require_relative 'lib/uri/redis'
=> true
irb(main):002> require_relative 'lib/uri/redis/version'
/src/lib/uri/redis/version.rb:5:in `<module:URI>': Redis is not a module (TypeError)
/src/lib/uri/redis.rb:19: previous definition of Redis was here
[...]
```

Removed the uri part to "alias" it to id

Timeout part could be removed, as far as I remember it was for redis > 5.X 

I haven't updated the version, let me know what's best here, 1.3.0 ?

Related to onetimesecret/onetimesecret/issues/238 

cc @delano 