### PR TITLE
docs: add authentication examples and clarify password-only URI format

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,14 @@
 URI-Valkey, CHANGES
 
+#### 1.5.0 (2024-12-15) ###############################
+
+* ADDED: Authentication documentation with examples for password-only
+  and username+password formats
+* ADDED: Warning about common password URL format mistake
+  (redis://pass@host vs redis://:pass@host)
+* ADDED: Environment variable examples for VALKEY_URL and REDIS_URL
+
+
 #### 1.4.0 (2024-06-15) ###############################
 
 * CHANGE: Monorepo structure for uri-redis and uri-valkey gems

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,9 @@ URI-Valkey, CHANGES
 
 * ADDED: Authentication documentation with examples for password-only
   and username+password formats
-* ADDED: Warning about common password URL format mistake
-  (redis://pass@host vs redis://:pass@host)
+* ADDED: Runtime warning when URI has username but no password, which
+  almost always indicates a misconfigured password-only URL
+  (redis://pass@host instead of redis://:pass@host)
 * ADDED: Environment variable examples for VALKEY_URL and REDIS_URL
 
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,55 @@ conf.to_s                 # => "valkey://localhost:6379/0"
 conf.conf                 # => {:host=>"localhost", :port=>6379, :db=>0, :ssl=>false}
 ```
 
+## Authentication
+
+### Password-only authentication (most common)
+
+For Valkey/Redis servers using simple password authentication, use a **colon before the password** with an empty username:
+
+```ruby
+# Correct format - note the colon before the password
+uri = URI.parse 'valkey://:mysecretpassword@localhost:6379/0'
+uri.password              # => "mysecretpassword"
+uri.conf[:password]       # => "mysecretpassword"
+uri.conf                  # => {:host=>"localhost", :port=>6379, :db=>0, :ssl=>false, :password=>"mysecretpassword"}
+```
+
+> **⚠️ Common mistake:** Omitting the colon treats the password as a username!
+>
+> ```ruby
+> # WRONG - password is parsed as username, not password!
+> uri = URI.parse 'valkey://mysecretpassword@localhost:6379/0'
+> uri.user                  # => "mysecretpassword"
+> uri.password              # => nil
+> uri.conf[:password]       # => nil  # No password will be sent!
+> ```
+
+### Username and password authentication (Valkey/Redis 6+ ACLs)
+
+For Valkey or Redis 6+ servers using ACL with username/password:
+
+```ruby
+uri = URI.parse 'valkey://myuser:mypassword@localhost:6379/0'
+uri.user                  # => "myuser"
+uri.password              # => "mypassword"
+uri.conf[:password]       # => "mypassword"
+```
+
+### Environment variable examples
+
+```bash
+# Password-only (most common)
+export VALKEY_URL="valkey://:mysecretpassword@localhost:6379/0"
+export REDIS_URL="redis://:mysecretpassword@localhost:6379/0"
+
+# Username + password (Valkey/Redis 6+ ACLs)
+export VALKEY_URL="valkey://myuser:mypassword@localhost:6379/0"
+
+# No authentication (development only)
+export VALKEY_URL="valkey://localhost:6379/0"
+```
+
 ### SSL Support
 
 SSL is supported by using the `valkeys` scheme:

--- a/README.md
+++ b/README.md
@@ -74,12 +74,15 @@ export REDIS_URL="redis://:mysecretpassword@localhost:6379/0"
 
 # Username + password (Valkey/Redis 6+ ACLs)
 export VALKEY_URL="valkey://myuser:mypassword@localhost:6379/0"
+export REDIS_URL="redis://myuser:mypassword@localhost:6379/0"
 
 # No authentication (development only)
 export VALKEY_URL="valkey://localhost:6379/0"
+export REDIS_URL="redis://localhost:6379/0"
 ```
 
 ### SSL Support
+
 
 SSL is supported by using the `valkeys` scheme:
 

--- a/lib/uri/perfect_strangers.rb
+++ b/lib/uri/perfect_strangers.rb
@@ -71,7 +71,7 @@ module URI
       if user && !user.empty? && password.nil?
         warn "[uri-redis] Warning: URI has username '#{user}' but no password. " \
              "For password-only auth, use '#{scheme}://:password@host' format. " \
-             "See: https://github.com/delano/uri-valkey#authentication"
+             'See: https://github.com/delano/uri-valkey#authentication'
       end
 
       hsh

--- a/lib/uri/perfect_strangers.rb
+++ b/lib/uri/perfect_strangers.rb
@@ -64,6 +64,16 @@ module URI
       }.merge(parse_query(query))
       hsh[:password] = password if password
       hsh[:timeout] = hsh[:timeout].to_i if hsh.key?(:timeout)
+
+      # Warn about likely misconfiguration: username without password
+      # This almost always indicates the user meant to use password-only auth
+      # but formatted the URL as redis://password@host instead of redis://:password@host
+      if user && !user.empty? && password.nil?
+        warn "[uri-redis] Warning: URI has username '#{user}' but no password. " \
+             "For password-only auth, use '#{scheme}://:password@host' format. " \
+             "See: https://github.com/delano/uri-valkey#authentication"
+      end
+
       hsh
     end
 

--- a/lib/uri/redis/version.rb
+++ b/lib/uri/redis/version.rb
@@ -5,7 +5,7 @@ require 'uri/generic'
 
 module URI
   class Redis < URI::Generic
-    VERSION = '1.4.0'
+    VERSION = '1.5.0'
     SUMMARY = 'A Ruby library for parsing, building and normalizing redis URLs'
   end
 end

--- a/lib/uri/valkey/version.rb
+++ b/lib/uri/valkey/version.rb
@@ -5,7 +5,7 @@ require 'uri/generic'
 
 module URI
   class Valkey < URI::Generic
-    VERSION = '1.4.0'
+    VERSION = '1.5.0'
     SUMMARY = 'A Ruby library for parsing, building and normalizing valkey URLs'
   end
 end


### PR DESCRIPTION
### **User description**
## Summary

Add comprehensive authentication documentation to README addressing a common source of confusion and production issues.

## Changes

- **New Authentication section** in README with:
  - Password-only authentication format (`redis://:password@host`)
  - Username+password format for Redis/Valkey 6+ ACLs
  - Prominent warning about the common mistake (`redis://password@host` parses password as username)
  - Environment variable examples for `VALKEY_URL` and `REDIS_URL`

- **Version bump** to 1.5.0 for both uri-redis and uri-valkey gems

- **CHANGES.txt** updated with new version entry

## Problem This Solves

Users commonly format password-only Redis/Valkey URLs as:
```
redis://mypassword@localhost:6379/0
```

This is **incorrect** - the URI parser interprets `mypassword` as a username, not a password:

```ruby
uri = URI.parse("redis://mypassword@localhost:6379/0")
uri.user      # => "mypassword"
uri.password  # => nil
uri.conf[:password]  # => nil  # No password sent to Redis!
```

The correct format requires a colon before the password:
```
redis://:mypassword@localhost:6379/0
```

This caused a real production outage that was difficult to debug because:
1. The error message (`NOAUTH Authentication required`) doesn't indicate the URL parsing issue
2. The `serverid` method sanitizes credentials from display, hiding that no password was present
3. Users see their env var clearly contains a password and are confused

Fixes #25


___

### **PR Type**
Documentation


___

### **Description**
- Add comprehensive authentication documentation to README

- Include password-only and username+password authentication examples

- Highlight common URI format mistake with prominent warning

- Bump version to 1.5.0 for both gems


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md"] -->|"Add Authentication section"| B["Password-only format"]
  A -->|"Add Authentication section"| C["Username+password format"]
  A -->|"Add Authentication section"| D["Environment variables"]
  A -->|"Add Authentication section"| E["Common mistake warning"]
  F["Version files"] -->|"Bump to 1.5.0"| G["uri-redis & uri-valkey"]
  H["CHANGES.txt"] -->|"Document changes"| I["Version 1.5.0 entry"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add comprehensive authentication documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add new "Authentication" section with three subsections<br> <li> Document password-only authentication format with colon prefix<br> <li> Include prominent warning about common mistake of omitting colon<br> <li> Add username+password authentication examples for Redis 6+ ACLs<br> <li> Provide environment variable examples for VALKEY_URL and REDIS_URL</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/uri-valkey/pull/26/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGES.txt</strong><dd><code>Document version 1.5.0 changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGES.txt

<ul><li>Add new version 1.5.0 entry dated 2024-12-15<br> <li> Document authentication documentation additions<br> <li> Note warning about password URL format mistake<br> <li> List environment variable examples as new features</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/uri-valkey/pull/26/files#diff-59130575b4fb2932c957db2922977d7d89afb0b2085357db1a14615a2fcad776">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.rb</strong><dd><code>Bump uri-redis version to 1.5.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/uri/redis/version.rb

- Bump VERSION from '1.4.0' to '1.5.0'


</details>


  </td>
  <td><a href="https://github.com/delano/uri-valkey/pull/26/files#diff-fef88139544f3e38eafce3eaaad8429f2023658b0ecdacf53f423b3e6c458b3b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>version.rb</strong><dd><code>Bump uri-valkey version to 1.5.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/uri/valkey/version.rb

- Bump VERSION from '1.4.0' to '1.5.0'


</details>


  </td>
  <td><a href="https://github.com/delano/uri-valkey/pull/26/files#diff-78d525c2ab0d971da6c581dc5b854fdef11cd2018756012c81e4864076c3c97a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

